### PR TITLE
Add signup email confirmation template

### DIFF
--- a/config/templates/account/email/email_confirmation_message.html
+++ b/config/templates/account/email/email_confirmation_message.html
@@ -1,0 +1,118 @@
+{% load i18n %}
+{% load i18n %}
+{% load account %}
+{% autoescape off %}
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <meta charset="UTF-8" />
+      <style>
+        body {
+          font-family: 'Helvetica', Arial, sans-serif;
+          line-height: 1.6;
+          max-width: 600px;
+          margin: 0 auto;
+          padding: 20px;
+          background-color: #f5f5f5;
+        }
+        
+        .email-container {
+          background-color: white;
+          padding: 30px;
+          border-radius: 8px;
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        
+        .header {
+          text-align: center;
+          margin-bottom: 30px;
+        }
+        
+        .logo {
+          font-size: 24px;
+          color: #333;
+          font-weight: bold;
+          margin-bottom: 10px;
+        }
+        
+        .greeting {
+          color: #2c3e50;
+          font-size: 18px;
+          margin-bottom: 20px;
+        }
+        
+        .content {
+          color: #444;
+          margin-bottom: 30px;
+        }
+        
+        .button {
+          display: inline-block;
+          padding: 12px 24px;
+          background-color: #3498db;
+          color: white;
+          text-decoration: none;
+          border-radius: 4px;
+          font-weight: bold;
+          margin: 20px 0;
+        }
+        
+        .button:hover {
+          background-color: #2980b9;
+        }
+        
+        .footer {
+          margin-top: 30px;
+          padding-top: 20px;
+          border-top: 1px solid #eee;
+          font-size: 14px;
+          color: #666;
+          text-align: center;
+        }
+        
+        .warning {
+          background-color: #fff3cd;
+          border: 1px solid #ffeeba;
+          color: #856404;
+          padding: 15px;
+          border-radius: 4px;
+          margin: 20px 0;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="email-container">
+        <div class="header">
+          <div class="logo">{{ current_site.name }}</div>
+        </div>
+
+        <div class="greeting">
+          {% trans 'Hi' %} {% if user.get_full_name %}
+            {{ user.get_full_name }}
+          {% else %}
+            {{ user.email }}
+          {% endif %},
+        </div>
+
+        <div class="content">
+          {% autoescape off %}
+            {% user_display user as user_display %}
+            {% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this email because user {{ user_display }} has given your email address to register an account on {{ site_domain }}.{% endblocktrans %}
+          {% endautoescape %}
+        </div>
+
+        <div style="text-align: center;">
+          <a href="{{ activate_url }}" class="button">{% trans 'Confirm Email Address' %}</a>
+        </div>
+
+        <div class="warning">
+          {% blocktrans %}If you did not request this verification, you can safely ignore this email.{% endblocktrans %}
+        </div>
+
+        <div class="footer">
+          {% blocktrans %}This is an automated email from {{ current_site.name }}. Please do not reply to this email.{% endblocktrans %}
+        </div>
+      </div>
+    </body>
+  </html>
+{% endautoescape %}

--- a/config/templates/account/email/email_confirmation_signup_message.html
+++ b/config/templates/account/email/email_confirmation_signup_message.html
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_message.html" %}


### PR DESCRIPTION
This pull request adds a new email confirmation template for the signup process. The template includes HTML markup and styling for the email content, including a header, greeting, content section, button for confirming the email address, a warning section, and a footer. The template is designed to be used in conjunction with the existing email confirmation message template.