### PR TITLE
Update 'Start here' button to link to signup page

### DIFF
--- a/home/templates/home/components/hero.html
+++ b/home/templates/home/components/hero.html
@@ -15,7 +15,7 @@
       <p class="text-lg md:text-xl text-white md:w-2/3 mb-8">Our solution streamlines and enables seamless business operations for Restaurant owners around the continent.</p>
       <div class="flex flex-col sm:flex-row gap-4 py-4 md:py-0 xl:py-8">
         <a href="https://forms.gle/PVNCmsyiQgdUC7KG9" class="px-8 py-2 text-center bg-primary text-white rounded-lg hover:bg-primary/50 transition-colors">Request Demo</a>
-        <a href="https://forms.gle/PVNCmsyiQgdUC7KG9" class="px-8 py-2 text-center bg-secondary text-white rounded-lg hover:bg-secondary/50 transition-colors">Start here</a>
+        <a href="{% url 'restaurant_signup' %}" class="px-8 py-2 text-center bg-secondary text-white rounded-lg hover:bg-secondary/50 transition-colors">Start here</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Change the 'Start here' button to direct users to the signup page instead of the demo request form.